### PR TITLE
[modify] 修改rtthread针对CHIP Matter平台的lwip功能适配

### DIFF
--- a/adaptation-layer/src/lwip/BUILD.gn
+++ b/adaptation-layer/src/lwip/BUILD.gn
@@ -176,10 +176,8 @@ if (current_os == "zephyr" || current_os == "mbed") {
       sources += [ "standalone/sys_arch.c" ]
     } else if (lwip_platform == "cyw30739") {
     } else if (lwip_platform == "mt793x") {
-    } else if(lwip_platform == "rtthread"){
-      public += [
-        "rtthread/arch/sys_arch.h",
-      ]
+    } else if(lwip_platform == "rtthread" && lwip_platform != freertos){
+      public += [ "rtthread/arch/sys_arch.h" ]
       sources += [ "rtthread/sys_arch.c" ]
     } else {
       public += [

--- a/adaptation-layer/src/lwip/rtthread/arch/sys_arch.h
+++ b/adaptation-layer/src/lwip/rtthread/arch/sys_arch.h
@@ -24,23 +24,31 @@
 #ifndef CHIP_LWIP_RTTHREAD_ARCH_SYS_ARCH_H
 #define CHIP_LWIP_RTTHREAD_ARCH_SYS_ARCH_H
 
-#include "arch/cc.h"
 #include <rtthread.h>
+#include <lwip/opt.h>
+#include <lwip/sys.h>
 
 #define SYS_MBOX_NULL RT_NULL
 #define SYS_SEM_NULL  RT_NULL
 
 typedef rt_uint32_t sys_prot_t;
 
-#define SYS_MBOX_SIZE 10
-#define SYS_LWIP_TIMER_NAME "timer"
-#define SYS_LWIP_MBOX_NAME "mbox"
-#define SYS_LWIP_SEM_NAME "sem"
-#define SYS_LWIP_MUTEX_NAME "mu"
-
-typedef rt_sem_t sys_sem_t;
 typedef rt_mutex_t sys_mutex_t;
-typedef rt_mailbox_t  sys_mbox_t;
+typedef rt_sem_t sys_sem_t;
+typedef rt_mailbox_t sys_mbox_t;
 typedef rt_thread_t sys_thread_t;
+
+#ifdef LWIP_DEBUG
+#define LWIP_PLATFORM_DIAG(x) rt_kprintf x
+#define LWIP_ERROR(message, expression, handler)       \
+    do                                                 \
+    {                                                  \
+        if (!(expression))                            \
+        {                                              \
+            LWIP_PLATFORM_DIAG((message));             \
+            handler;                                   \
+        }                                              \
+    } while (0)
+#endif
 
 #endif /* CHIP_LWIP_RTTHREAD_ARCH_SYS_ARCH_H */

--- a/docs/log.md
+++ b/docs/log.md
@@ -133,6 +133,12 @@ Limitation:
 /* 2023.9.22 */
   - adaptation-layer/src/lwip/rtthread/BUILD.gn
   - adaptation-layer/src/lwip/rtthread/lwip.gni
+
+/* 2023.9.23 */
++ in adaptation-layer/src/lwip/ directory:
+  - adaptation-layer/src/lwip/rtthread/sys_arch.c
+  - adaptation-layer/src/lwip/rtthread/sys_arch.h
+  - adaptation-layer/src/lwip/rtthread/BUILD.gn
 ```
 
 ## Tips


### PR DESCRIPTION
ps: 剔除目前来说不必要的功能，基于其他平台下lwip的实现，仅实现如下功能：

* sys_sem_new()：创建一个新的信号量并使用给定的计数初始化；
* sys_sem_free()：释放一个信号量；
* sys_sem_signal()：发送信号到信号量；
* sys_arch_sem_wait()：阻塞当前线程，等待信号量被触发，可选超时；
* sys_mutex_new()：创建一个新的互斥锁；
* sys_mutex_free()：释放一个互斥锁；
* sys_mutex_lock()：锁定互斥锁；
* sys_mutex_unlock()：解锁互斥锁；
* sys_mbox_new()：创建一个指定大小的空邮箱；
* sys_mbox_free()：释放邮箱；
* sys_mbox_post()：将消息发布到邮箱，如果邮箱已满则阻塞；
* sys_arch_mbox_fetch()：等待邮箱中出现新消息，可选超时；
* sys_arch_mbox_tryfetch()：尝试从邮箱中获取消息，非阻塞；
* sys_mbox_trypost()：尝试将消息发布到邮箱，非阻塞；
* sys_thread_new()：启动一个新线程，指定名称、优先级和入口函数；
* sys_thread_finish()：结束并删除一个线程；
* sys_now()：获取当前系统时间（毫秒）；
* sys_arch_protect()：保护当前执行上下文以确保原子性；
* sys_arch_unprotect()：取消保护之前使用sys_arch_protect保护的执行上下文。